### PR TITLE
Bump to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.1 (2021-04-22)
+
+- Add backport extension entrypoints to classical notebook server (#48)
+- Pass directly the configuration object to manager (#47)  
+  This breaks an internal API 
+
 ## 3.0.0 (2021-04-18)
 
 - Port to JupyterLab 3 (#29)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/pullrequests",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Pull Requests for JupyterLab",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Publish a new version that add support for legacy notebook - to support JupyterHub deployment...