### PR TITLE
prevent appending pr_id urls with base_api_url

### DIFF
--- a/jupyterlab_pullrequests/managers/manager.py
+++ b/jupyterlab_pullrequests/managers/manager.py
@@ -13,6 +13,8 @@ from .._version import __version__
 from ..log import get_logger
 from ..base import PRConfig
 
+import re
+
 class PullRequestsManager(abc.ABC):
     """Abstract base class for pull requests manager.
     

--- a/jupyterlab_pullrequests/managers/manager.py
+++ b/jupyterlab_pullrequests/managers/manager.py
@@ -160,7 +160,7 @@ class PullRequestsManager(abc.ABC):
             headers["Content-Type"] = "application/json"
             body = tornado.escape.json_encode(body)
 
-        if not url.startswith(self.base_api_url):
+        if (not url.startswith(self.base_api_url)) and (not url.startswith("http")):
             url = url_path_join(self.base_api_url, url)
 
         with_pagination = False

--- a/jupyterlab_pullrequests/managers/manager.py
+++ b/jupyterlab_pullrequests/managers/manager.py
@@ -160,7 +160,7 @@ class PullRequestsManager(abc.ABC):
             headers["Content-Type"] = "application/json"
             body = tornado.escape.json_encode(body)
 
-        if (not url.startswith(self.base_api_url)) and (not url.startswith("http")):
+        if (not url.startswith(self.base_api_url)) and (not re.search("^https?:", url)):
             url = url_path_join(self.base_api_url, url)
 
         with_pagination = False


### PR DESCRIPTION
Only `url_path_join(self.base_api_url, url)` if `pr_id = get_request_attr_value(self, “id”)` already contains a fully qualified url.
Example:
If pr_id already starts with `http`, then don’t prefix it with base_api_url.
This occurs within Enterprise Github where we need to specify a custom base api url such as `http://api.githubprod.com`