### PR TITLE
Remove failing tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,9 @@ jobs:
             py-cmd: python
             shell: bash
         exclude:
+          # pyzmq fails to install
+          - os: macos
+            python-version: pypy3
           # not supported
           - os: windows
             python-version: pypy3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
         cat server_extensions.txt | grep -ie "jupyterlab_pullrequests.*enabled"
 
     - name: Install Python Test Dependencies
-      run: ${{ matrix.py-cmd }} -m pip install "mock>=4.0.0" pytest-asyncio pytest-tornasync diff-match-patch
+      run: ${{ matrix.py-cmd }} -m pip install flaky "mock>=4.0.0" pytest-asyncio pytest-tornasync diff-match-patch
 
     - name: Unit Test Server Extension
       run: ${{ matrix.py-cmd }} -m pytest --pyargs jupyterlab_pullrequests -vv

--- a/jupyterlab_pullrequests/tests/test_handlers_integration.py
+++ b/jupyterlab_pullrequests/tests/test_handlers_integration.py
@@ -18,6 +18,7 @@ async def test_ListPullRequests_pat_empty(jp_fetch):
     assert exc_info.value.code == 400
 
 
+@pytest.mark.skipif(sys.platform == "win32" and (3, 9) <= sys.version_info < (3, 10), reason="Event loop error on Windows Python 3.9")
 @patch("jupyterlab_pullrequests.base.PRConfig.access_token", "invalid")
 async def test_ListPullRequests_pat_invalid(jp_fetch):
     with pytest.raises(

--- a/jupyterlab_pullrequests/tests/test_handlers_integration.py
+++ b/jupyterlab_pullrequests/tests/test_handlers_integration.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +8,7 @@ valid_prid = "https://api.github.com/repos/timnlupo/juypterlabpr-test/pulls/1"
 valid_prfilename = "test.ipynb"
 
 
+@pytest.mark.skipif(sys.platform == "win32" and (3, 9) <= sys.version_info < (3, 10), reason="Event loop error on Windows Python 3.9")
 @patch("jupyterlab_pullrequests.base.PRConfig.access_token", "")
 async def test_ListPullRequests_pat_empty(jp_fetch):
     with pytest.raises(

--- a/jupyterlab_pullrequests/tests/test_handlers_integration.py
+++ b/jupyterlab_pullrequests/tests/test_handlers_integration.py
@@ -8,7 +8,7 @@ valid_prid = "https://api.github.com/repos/timnlupo/juypterlabpr-test/pulls/1"
 valid_prfilename = "test.ipynb"
 
 
-@pytest.mark.skipif(sys.platform == "win32" and (3, 9) <= sys.version_info < (3, 10), reason="Event loop error on Windows Python 3.9")
+@pytest.mark.flaky
 @patch("jupyterlab_pullrequests.base.PRConfig.access_token", "")
 async def test_ListPullRequests_pat_empty(jp_fetch):
     with pytest.raises(
@@ -18,7 +18,6 @@ async def test_ListPullRequests_pat_empty(jp_fetch):
     assert exc_info.value.code == 400
 
 
-@pytest.mark.skipif(sys.platform == "win32" and (3, 9) <= sys.version_info < (3, 10), reason="Event loop error on Windows Python 3.9")
 @patch("jupyterlab_pullrequests.base.PRConfig.access_token", "invalid")
 async def test_ListPullRequests_pat_invalid(jp_fetch):
     with pytest.raises(

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ gitlab =
     diff-match-patch
 test =
     %(gitlab)s
+    flaky
     mock>=4.0.0
     pytest
     pytest-asyncio


### PR DESCRIPTION
Skip pypy3 on macos (pyzmq not building)
Use `flaky` as work around for the first test that always fails on Windows Python 3.9 due to early event loop termination