### PR TITLE
Allow later jupyterlab-git dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ setup_requires =
 install_requires =
     entrypoints >=0.2.2
     jupyterlab ~=3.0
-    jupyterlab-git >=0.30.0,<0.40.0a0
+    jupyterlab-git >=0.30.0,<=0.41.0
 packages = find:
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ setup_requires =
 install_requires =
     entrypoints >=0.2.2
     jupyterlab ~=3.0
-    jupyterlab-git >=0.30.0,<=0.41.0
+    jupyterlab-git >=0.30.0,<0.50.0
 packages = find:
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
jupyterlab-git v0.41.0 works with this project and removes  some deprecation warnings